### PR TITLE
fix underline hover effect issue #488

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -46,15 +46,6 @@ a {
   text-decoration: none;
 }
 
-a:hover {
-  text-decoration: underline;
-}
-
-a,
-a:hover {
-  color: #008F01;
-}
-
 img {
   max-width: 100%;
 }


### PR DESCRIPTION
Fix the underline and green text when you hover the text in a card, as described in the issue #488