### PR TITLE
end date typo

### DIFF
--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -30,7 +30,7 @@ export const getLastEndDate = dates =>
     (lastDate, current) =>
       !lastDate
         ? current.endDate
-        : new Date(current.endDate) < new Date(lastDate)
+        : new Date(current.endDate) > new Date(lastDate)
           ? current.endDate
           : lastDate,
     null

--- a/src/utils/formatDate.test.js
+++ b/src/utils/formatDate.test.js
@@ -83,7 +83,7 @@ describe('getLastEndDate', () => {
         testDate30,
         testDate31,
       ])
-    ).toEqual(testDate28.endDate);
+    ).toEqual(testDate31.endDate);
   });
 });
 


### PR DESCRIPTION
Fixed the typo that provoked the issue in  #494, returning the earliest date and not the last one as expected