### PR TITLE
Add event to google calendar feature

### DIFF
--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -14,8 +14,14 @@ import * as COLORS from '../constants/colors';
 const getCalendarURl = (date, startTime, endTime, name) => {
   let dateStart;
   let dateEnd;
-  dateStart = getCalendarFormat(date, startTime);
-  dateEnd = getCalendarFormat(date, endTime);
+
+  if (!startTime && !endTime) {
+    dateStart = getCalendarFormat(date, null);
+    dateEnd = getCalendarFormat(date, null);
+  } else if (startTime) {
+    dateStart = getCalendarFormat(date, startTime);
+    dateEnd = (!endTime) ? getCalendarFormat(date, startTime) : getCalendarFormat(date, endTime);
+  }
 
   return `http://www.google.com/calendar/event?action=TEMPLATE&text=${name}&dates=${dateStart}/${dateEnd}`
 };
@@ -70,7 +76,7 @@ export default ({ data }) => {
 
       {!event.dateAndRegistration && (
         <div>
-          <a href ={getCalendarURl(event.startDate, event.startTime, event.startTime, event.name)}>
+          <a href ={getCalendarURl(event.startDate, event.startTime, event.endTime, event.name)}>
             ✚ gCal
           </a>
           <p>

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -8,8 +8,17 @@ import { H1 } from '../components/headers';
 import Breadcrumbs from '../components/Breadcrumbs';
 import EmbedForm from '../components/EmbedForm';
 import HoverCard from '../components/HoverCard';
-import { shortFormatDate, getDayOfWeek } from '../utils/formatDate';
+import { shortFormatDate, getDayOfWeek, getCalendarFormat} from '../utils/formatDate';
 import * as COLORS from '../constants/colors';
+
+const getCalendarURl = (date, startTime, endTime, name) => {
+  let dateStart;
+  let dateEnd;
+  dateStart = getCalendarFormat(date, startTime);
+  dateEnd = getCalendarFormat(date, endTime);
+
+  return `http://www.google.com/calendar/event?action=TEMPLATE&text=${name}&dates=${dateStart}/${dateEnd}`
+};
 
 const Image = styled.div`
   margin: 0 auto;
@@ -61,6 +70,9 @@ export default ({ data }) => {
 
       {!event.dateAndRegistration && (
         <div>
+          <a href ={getCalendarURl(event.startDate, event.startTime, event.startTime, event.name)}>
+            ✚ gCal
+          </a>
           <p>
             {event.startDate &&
               `${getDayOfWeek(event.startDate)} ${shortFormatDate(
@@ -95,6 +107,9 @@ export default ({ data }) => {
                 <HoverCard>
                   <CardInner>
                     <h2>{e.timeDescription}</h2>
+                    <a href={getCalendarURl(e.startDate, e.startTime, e.endTime, event.name)}>
+                      ✚ gCal
+                    </a>
                     <p>
                       {shortFormatDate(e.startDate)} -{' '}
                       {shortFormatDate(e.endDate)}

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -8,23 +8,8 @@ import { H1 } from '../components/headers';
 import Breadcrumbs from '../components/Breadcrumbs';
 import EmbedForm from '../components/EmbedForm';
 import HoverCard from '../components/HoverCard';
-import { shortFormatDate, getDayOfWeek, getCalendarFormat} from '../utils/formatDate';
+import { shortFormatDate, getDayOfWeek, getCalendarURl} from '../utils/formatDate';
 import * as COLORS from '../constants/colors';
-
-const getCalendarURl = (date, startTime, endTime, name) => {
-  let dateStart;
-  let dateEnd;
-
-  if (!startTime && !endTime) {
-    dateStart = getCalendarFormat(date, null);
-    dateEnd = getCalendarFormat(date, null);
-  } else if (startTime) {
-    dateStart = getCalendarFormat(date, startTime);
-    dateEnd = (!endTime) ? getCalendarFormat(date, startTime) : getCalendarFormat(date, endTime);
-  }
-
-  return `http://www.google.com/calendar/event?action=TEMPLATE&text=${name}&dates=${dateStart}/${dateEnd}`
-};
 
 const Image = styled.div`
   margin: 0 auto;

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -63,4 +63,12 @@ export const getFutureEvents = events => {
     .sort((a, b) => new Date(a.startDate) > new Date(b.startDate));
 };
 
+export const getCalendarFormat = (date, time) => {
+  const formatDate = 'yyyy-MM-dd h:mma';
+  const inputDate = (date + " " + time);
+  const isoFormat = DateTime.fromFormat(inputDate, formatDate).toISO();
+  var formatting = isoFormat.slice(0, 19).replace(/:|-/g, '') ;//+ 'Z-4';
+  return formatting;
+};
+
 export default formatDate;

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -70,4 +70,19 @@ export const getCalendarFormat = (date, time) => {
   return isoFormat.split('.')[0].replace(/:|-/g, '');
 };
 
+export const getCalendarURl = (date, startTime, endTime, name) => {
+  let dateStart;
+  let dateEnd;
+
+  if (!startTime && !endTime) {
+    dateStart = getCalendarFormat(date, null);
+    dateEnd = getCalendarFormat(date, null);
+  } else if (startTime) {
+    dateStart = getCalendarFormat(date, startTime);
+    dateEnd = (!endTime) ? getCalendarFormat(date, startTime) : getCalendarFormat(date, endTime);
+  }
+
+  return `http://www.google.com/calendar/event?action=TEMPLATE&text=${name}&dates=${dateStart}/${dateEnd}`
+};
+
 export default formatDate;

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -64,11 +64,10 @@ export const getFutureEvents = events => {
 };
 
 export const getCalendarFormat = (date, time) => {
-  const formatDate = 'yyyy-MM-dd h:mma';
-  const inputDate = (date + " " + time);
+  const formatDate = (!time) ? 'yyyy-MM-dd' : 'yyyy-MM-dd h:mma';
+  const inputDate = (!time) ? date : `${date} ${time}`;
   const isoFormat = DateTime.fromFormat(inputDate, formatDate).toISO();
-  var formatting = isoFormat.slice(0, 19).replace(/:|-/g, '') ;//+ 'Z-4';
-  return formatting;
+  return isoFormat.split('.')[0].replace(/:|-/g, '');
 };
 
 export default formatDate;

--- a/src/utils/formatDate.test.js
+++ b/src/utils/formatDate.test.js
@@ -10,7 +10,7 @@ describe('formatDate', () => {
 });
 
 describe('longFormatDate', () => {
-  test('it should format 2018-12-31 as "December 31, 20018"', () => {
+  test('it should format 2018-12-31 as "December 31, 2018"', () => {
     const testDate = new Date('2018-12-31:00:00:00').toISOString();
     expect(formatDate.longFormatDate(testDate)).toBe('December 31, 2018');
   });
@@ -336,5 +336,13 @@ describe('getFutureEvents', () => {
       expect(futureEvents[0].id).toBe(oldestEventId);
       expect(futureEvents[1].id).toBe(newestEventId);
     });
+  });
+});
+
+describe('getCalendarFormat', () => {
+  test('it should format arguments "2018-10-01" and "9:00am" as "20181001T090000"', () => {
+    const testDate = "2018-10-01";
+    const testTime = "9:00am";
+    expect(formatDate.getCalendarFormat(testDate,testTime)).toBe('20181001T090000');
   });
 });

--- a/src/utils/formatDate.test.js
+++ b/src/utils/formatDate.test.js
@@ -346,3 +346,15 @@ describe('getCalendarFormat', () => {
     expect(formatDate.getCalendarFormat(testDate,testTime)).toBe('20181001T090000');
   });
 });
+
+
+describe('getCalendarURl', () => {
+  test('it should format arguments "2018-10-01", "9:00am", "11:00am", "October_Event" as the expectedResult seen below', () => {
+    const testDate = "2018-10-01";
+    const startTime = "9:00am";
+    const endTime = "11:00am";
+    const name = "October_Event";
+    const expectedResult = `http://www.google.com/calendar/event?action=TEMPLATE&text=October_Event&dates=20181001T090000/20181001T110000`;
+    expect(formatDate.getCalendarURl(testDate, startTime, endTime, name)).toBe(expectedResult);
+  });
+});


### PR DESCRIPTION
Addresses issues #405 

This PR adds google calendar links to event pages. 

Some notes:
* I did not add the "Z" to the end of the ISO string for startdate and enddate in the google calendar URL link (see https://gist.github.com/cdncat/95801f3237424909f9372ceabe6d4679) because it seems to adjust the event times based on the user's local time settings
 * if no endtime is specified, the event will run from startime and end at starttime
* if no end time nor start time are specified then it will be an event starting at 12am of the specified date

I tried handling three cases for event pages (assuming date is always available): 
1. end time and start time do not exist
2. start time exists but end time does not
3. start time and end time both exists

I did some basic testing that it works for various events but can someone please test that the times is correct when you click on the google link? 